### PR TITLE
perf: consume less CPU cycles, by understanding tokio

### DIFF
--- a/src/alerts/mod.rs
+++ b/src/alerts/mod.rs
@@ -330,7 +330,7 @@ pub struct RollingWindow {
     // should always be "now"
     pub eval_end: String,
     // x minutes (5m)
-    pub eval_frequency: u32,
+    pub eval_frequency: u64,
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize, Clone)]
@@ -641,7 +641,7 @@ impl AlertConfig {
         columns
     }
 
-    pub fn get_eval_frequency(&self) -> u32 {
+    pub fn get_eval_frequency(&self) -> u64 {
         match &self.eval_type {
             EvalConfig::RollingWindow(rolling_window) => rolling_window.eval_frequency,
         }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -22,7 +22,7 @@ use std::panic::AssertUnwindSafe;
 use tokio::sync::oneshot;
 use tokio::time::{interval_at, sleep, Duration, Instant};
 use tokio::{select, task};
-use tracing::{error, info, warn, trace};
+use tracing::{error, info, trace, warn};
 
 use crate::alerts::{alerts_utils, AlertConfig, AlertError};
 use crate::option::CONFIG;
@@ -63,7 +63,7 @@ where
                 if warned_once {
                     warn!(
                         "Task '{task_name}' started at: {start_time:?} took longer than expected: {:?} (threshold: {threshold:?})",
-                        start_time.elapsed()
+                        start_time.elapsed() - threshold
                     );
                 }
                 break res.expect("Task handle shouldn't error");

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -55,14 +55,14 @@ where
         select! {
             _ = sleep(threshold), if !warned_once => {
                 warn!(
-                    "Task '{task_name}' started at: {start_time:?} is taking longer than expected: (threshold: {threshold:?})",
+                    "Task '{task_name}' is taking longer than expected: (threshold: {threshold:?})",
                 );
                 warned_once = true;
             },
             res = &mut future => {
                 if warned_once {
                     warn!(
-                        "Task '{task_name}' started at: {start_time:?} took longer than expected: {:?} (threshold: {threshold:?})",
+                        "Task '{task_name}' took longer than expected: {:?} (threshold: {threshold:?})",
                         start_time.elapsed() - threshold
                     );
                 }


### PR DESCRIPTION
<!-- Thanks for trying to help us make Parseable be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

We are currently consuming extra CPU cycles by depending on a loop to perform checks, this can be avoided by utilizing tokio to the full extent.
<!-- Describe the goal of this PR -->

```
2025-02-05T08:33:05.52955Z  WARN                        main ThreadId(01) parseable::sync:67: Task 'arrow_conversion' took longer than expected: 70.002833792s (threshold: 30s)
2025-02-05T08:33:05.529766Z TRACE                        main ThreadId(01) parseable::sync:162: Converting Arrow to Parquet... 
2025-02-05T08:33:06.444647Z TRACE                        main ThreadId(01) hyper::client::pool:768: idle interval checking for expired
2025-02-05T08:33:15.530173Z  WARN                        main ThreadId(01) parseable::sync:60: Task 'object_store_sync' is taking longer than expected: (threshold: 15s)
2025-02-05T08:33:35.531833Z  WARN                        main ThreadId(01) parseable::sync:60: Task 'arrow_conversion' is taking longer than expected: (threshold: 30s)
2025-02-05T08:34:00.519917Z TRACE                        main ThreadId(01) parseable::sync:220: Flushing Arrows to disk...
2025-02-05T08:34:36.444804Z TRACE                        main ThreadId(01) hyper::client::pool:768: idle interval checking for expired
2025-02-05T08:34:40.531807Z  WARN                        main ThreadId(01) parseable::sync:67: Task 'object_store_sync' took longer than expected: 85.001987917s (threshold: 15s)
2025-02-05T08:34:40.531963Z TRACE                        main ThreadId(01) parseable::sync:98: Syncing Parquets to Object Store... 
2025-02-05T08:34:45.532823Z  WARN                        main ThreadId(01) parseable::sync:67: Task 'arrow_conversion' took longer than expected: 70.00224s (threshold: 30s)
2025-02-05T08:34:45.533009Z TRACE                        main ThreadId(01) parseable::sync:162: Converting Arrow to Parquet... 
2025-02-05T08:34:55.534845Z  WARN                        main ThreadId(01) parseable::sync:60: Task 'object_store_sync' is taking longer than expected: (threshold: 15s)
2025-02-05T08:35:00.520294Z TRACE                        main ThreadId(01) parseable::sync:220: Flushing Arrows to disk...
```

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested to ensure log ingestion and log query works.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.
